### PR TITLE
:sparkles: Use projectsV2 instead of projectNext

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,12 +42,12 @@ runs:
           const query = `
             query($login: String!, $projectNumber: Int!) {
               user(login: $login) {
-                projectNext(number: $projectNumber) {
+                projectV2(number: $projectNumber) {
                   id
                 }
               }
               organization(login: $login) {
-                projectNext(number: $projectNumber) {
+                projectV2(number: $projectNumber) {
                   id
                 }
               }
@@ -64,10 +64,10 @@ runs:
             }
           }
 
-          if (result.user && result.user.projectNext) {
-            return result.user.projectNext.id;
+          if (result.user && result.user.projectV2) {
+            return result.user.projectV2.id;
           }
-          if (result.organization && result.organization.projectNext) {
-            return result.organization.projectNext.id;
+          if (result.organization && result.organization.projectV2) {
+            return result.organization.projectV2.id;
           }
           return '';

--- a/action.yml
+++ b/action.yml
@@ -37,10 +37,7 @@ runs:
 
           const variables = {
             login: '${{ inputs.project-owner }}',
-            projectNumber: ${{ inputs.project-number }},
-            headers: {
-              'GraphQL-Features': 'projects_next_graphql'
-            }
+            projectNumber: ${{ inputs.project-number }}
           };
           const query = `
             query($login: String!, $projectNumber: Int!) {


### PR DESCRIPTION
- Deprecated な API の利用をやめる
- 関連する全てのアクションを更新する必要あり
    - `id` のプレフィックスが `PN_` から `PVT_` (Project Version Two の略かな？ V3 の場合どうするんだろ… 🤔 ) に変更になるため、projectNext クエリでヒットしなくなるはず